### PR TITLE
Sprint 7.2: Deal counter & General bugfixing

### DIFF
--- a/src/components/employees/employeeCard.tsx
+++ b/src/components/employees/employeeCard.tsx
@@ -219,8 +219,8 @@ export function EmployeeCardDragged({
       window.innerWidth || document.documentElement.clientWidth;
     const windowHeight =
       window.innerHeight || document.documentElement.clientHeight;
-    const detailViewHeight = 140;
-    const detailViewWidth = 315; // Assuming the detail view is also 140px wide
+    const detailViewHeight = 180;
+    const detailViewWidth = 315;
     // Get position relative to the document
     const rect = clickedElement.getBoundingClientRect();
     let top = rect.top + window.scrollY;
@@ -273,11 +273,29 @@ export function EmployeeCardDragged({
     const phase = (draggableEmployee.dragId as string).split("/")[1];
     if (phase === DealName.Opportunities) return "No Date";
     if (TLDatum) {
-      return TLDatum.toLocaleDateString("fr-BE", {
-        day: "2-digit",
-        month: "2-digit",
-        year: "numeric",
-      });
+      const today = new Date();
+      today.setHours(0, 0, 0, 0); // remove time part
+      const tomorrow = new Date(today);
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const yesterday = new Date(today);
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      const TLDatumDate = new Date(TLDatum);
+      TLDatumDate.setHours(0, 0, 0, 0); // remove time part
+
+      if (TLDatumDate.getTime() === today.getTime()) {
+        return "Vandaag";
+      } else if (TLDatumDate.getTime() === tomorrow.getTime()) {
+        return "Morgen";
+      } else if (TLDatumDate.getTime() === yesterday.getTime()) {
+        return "Gisteren";
+      } else {
+        return TLDatum.toLocaleDateString("fr-BE", {
+          day: "2-digit",
+          month: "2-digit",
+          year: "numeric",
+        });
+      }
     } else {
       return "No Date";
     }

--- a/src/components/teamleader/dealCard.tsx
+++ b/src/components/teamleader/dealCard.tsx
@@ -34,6 +34,32 @@ export default function DealCard({
     }
   }, [groupedDealsToWrap]);
 
+  const formatDate = (date: string) => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); // remove time part
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const targetDate = new Date(date);
+    targetDate.setHours(0, 0, 0, 0); // remove time part
+
+    if (targetDate.getTime() === today.getTime()) {
+      return "Vandaag";
+    } else if (targetDate.getTime() === tomorrow.getTime()) {
+      return "Morgen";
+    } else if (targetDate.getTime() === yesterday.getTime()) {
+      return "Gisteren";
+    } else {
+      return targetDate.toLocaleDateString("fr-BE", {
+        day: "2-digit",
+        month: "2-digit",
+        year: "2-digit",
+      });
+    }
+  };
+
   return (
     <Card
       variant={variant}
@@ -85,15 +111,7 @@ export default function DealCard({
         </div>
         <div className="flex items-center gap-2 justify-end font-normal text-sm">
           {groupedDeal.deal.estimated_closing_date ? (
-            <div>
-              {new Date(
-                groupedDeal.deal.estimated_closing_date,
-              ).toLocaleDateString("fr-BE", {
-                day: "2-digit",
-                month: "2-digit",
-                year: "2-digit",
-              })}
-            </div>
+            <div>{formatDate(groupedDeal.deal.estimated_closing_date)}</div>
           ) : (
             <div>no date</div>
           )}

--- a/src/components/teamleader/dealsColumn.tsx
+++ b/src/components/teamleader/dealsColumn.tsx
@@ -30,7 +30,7 @@ export default function DealsColumn() {
       const pmName = getAllPMs?.find((pm) => pm.id === PMId)?.first_name;
 
       return (
-        <div className="text-sm flex flex-row gap-1 items-center bg-primary text-white rounded-14 pl-1.5 pr-0.5">
+        <div className="text-sm flex flex-row gap-1 items-center bg-primary text-white rounded-14 pl-1.5 pr-1">
           <div>{pmName}</div>
           <div className="rounded-full bg-white text-black">
             <X
@@ -76,6 +76,7 @@ export default function DealsColumn() {
             <div className="flex flex-row gap-1">
               {handlePMPill()}
               {handleRolePill()}
+              {filteredDeals?.length}
               <FilterMenu />
             </div>
         </CardTitle>

--- a/src/components/teamleader/dealsColumn.tsx
+++ b/src/components/teamleader/dealsColumn.tsx
@@ -77,13 +77,16 @@ export default function DealsColumn() {
     <Card variant="columnDeals" size="columnDeals">
       <CardHeader>
         <CardTitle className="pb-1.5 truncate flex justify-between w-full">
-          Deals
-            <div className="flex flex-row gap-1">
-              {handlePMPill()}
-              {handleRolePill()}
-              {filteredDeals?.length}
-              <FilterMenu />
-            </div>
+          <div className="flex gap-1.5">
+            <div>Deals</div>
+            <div className="bg-white/30 rounded-14 h-1/2 w-0.5 flex self-center" />
+            {filteredDeals?.length}
+          </div>
+          <div className="flex flex-row gap-1">
+            {handlePMPill()}
+            {handleRolePill()}
+            <FilterMenu />
+          </div>
         </CardTitle>
       </CardHeader>
       <CardContent className="column p-1 flex flex-col gap-2 no-scrollbar overflow-auto h-[calc(100vh-9.625rem)]">

--- a/src/components/ui/actionMenu.tsx
+++ b/src/components/ui/actionMenu.tsx
@@ -20,6 +20,7 @@ export function ActionMenu() {
     setPMId,
     filteringCurrentRole,
     setFilteringCurrentRole,
+    refetch,
   } = useContext(DealContext);
   const [displayFilter, setDisplayFilter] = useState(false);
 
@@ -29,8 +30,8 @@ export function ActionMenu() {
     }
   }, [PMId, filteringCurrentRole, isFiltering]);
 
-  const handleRefresh = () => {
-    window.location.replace(window.location.href);
+  const handleRefresh = async () => {
+    await refetch();
   };
 
   const handleFullscreen = () => {

--- a/src/components/ui/datePicker.tsx
+++ b/src/components/ui/datePicker.tsx
@@ -61,6 +61,32 @@ export function DatePickerComponent({
     });
   };
 
+  const formatDate = (date: Date) => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); // remove time part
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const targetDate = new Date(date);
+    targetDate.setHours(0, 0, 0, 0); // remove time part
+
+    if (targetDate.getTime() === today.getTime()) {
+      return "Vandaag";
+    } else if (targetDate.getTime() === tomorrow.getTime()) {
+      return "Morgen";
+    } else if (targetDate.getTime() === yesterday.getTime()) {
+      return "Gisteren";
+    } else {
+      return targetDate.toLocaleDateString("fr-BE", {
+        day: "2-digit",
+        month: "2-digit",
+        year: "2-digit",
+      });
+    }
+  };
+
   return (
     <div className="relative inline-flex flex-col text-left">
       <DatePicker
@@ -71,15 +97,7 @@ export function DatePickerComponent({
         <Group className="flex bg-white/90 focus-within:bg-white group-open:bg-white transition focus-visible:ring-2">
           <AriaButton className="flex gap-1.5 outline-none items-center w-full px-2 p-1 bg-primary rounded-sm text-white justify-between">
             <CalendarIcon width={20} />
-            <div className="font-light flex h-5">
-              {date
-                .toLocaleDateString("fr-BE", {
-                  year: "2-digit",
-                  month: "2-digit",
-                  day: "2-digit",
-                })
-                .toString()}
-            </div>
+            <div className="font-light flex h-5">{formatDate(date)}</div>
           </AriaButton>
         </Group>
         <MyPopover>
@@ -106,7 +124,11 @@ export function DatePickerComponent({
                   {(date) => (
                     <CalendarCell
                       date={date}
-                      className=" w-8 h-8 outline-none cursor-default rounded-full flex items-center justify-center outside-month:text-gray-300 hover:bg-gray-100 pressed:bg-gray-200 selected:bg-violet-700 selected:text-white focus-visible:ring ring-violet-600/70 ring-offset-2"
+                      className={({ isOutsideMonth }) =>
+                        isOutsideMonth
+                          ? "text-gray-300 w-8 h-8 outline-none cursor-default rounded-full flex items-center justify-center hover:bg-gray-100 pressed:bg-gray-200 selected:bg-violet-700 selected:text-white focus-visible:ring ring-violet-600/70 ring-offset-2"
+                          : "w-8 h-8 outline-none cursor-default rounded-full flex items-center justify-center hover:bg-gray-100 pressed:bg-gray-200 selected:bg-violet-700 selected:text-white focus-visible:ring ring-violet-600/70 ring-offset-2"
+                      }
                     />
                   )}
                 </CalendarGridBody>

--- a/src/contexts/dealsProvider.tsx
+++ b/src/contexts/dealsProvider.tsx
@@ -8,9 +8,13 @@ import type {
   GroupedDeal,
   MongoEmployeeDeal,
 } from "~/lib/types";
-import type { SimplifiedDeal } from "~/server/api/routers/teamleader/types";
+import type {
+  SimplifiedDeal,
+  SimplifiedDealArray,
+} from "~/server/api/routers/teamleader/types";
 import { api } from "~/utils/api";
 import { dealPhases } from "~/lib/constants";
+import type { QueryObserverResult } from "@tanstack/react-query";
 
 type DealContextType = {
   deals: SimplifiedDeal[] | null | undefined; // Allow for null value to indicate loading state
@@ -35,6 +39,12 @@ type DealContextType = {
     employee: Employee,
   ) => string | undefined;
   updateDealProbability: (dealId: string, probability: number) => void;
+  refetch: () => Promise<
+    QueryObserverResult<
+      | { deals: SimplifiedDealArray; uniqueDeals: groupedDealFromDB[] }
+      | undefined
+    >
+  >;
 };
 
 export const DealContext = createContext<DealContextType>(
@@ -357,6 +367,7 @@ export const DealContextProvider: React.FC<DealContextProviderProps> = ({
         setFilteringCurrentRole,
         getCorrectDealId,
         updateDealProbability,
+        refetch,
       }}
     >
       {children}

--- a/src/contexts/dndProvider.tsx
+++ b/src/contexts/dndProvider.tsx
@@ -198,26 +198,29 @@ export const DropContextProvider: React.FC<DndContextProviderProps> = ({
     const columnName = overId.split("/")[1]!;
     // Highlight the correct column and/or deal
     if (overData?.type === "Employee") {
-      setActiveColumnId(overId.split("/")[1] as UniqueIdentifier);
+      setActiveColumnId(columnName);
+
+      const overDealId = overId.split("_")[1];
       if (
-        DealName.Opportunities.toString() === columnName ||
-        DealName.Proposed.toString() === columnName
+        columnName === DealName.Opportunities.toString() ||
+        columnName === DealName.Proposed.toString()
       ) {
+        setActiveDealId(overDealId);
         return;
       } else {
-        setActiveDealId(activeId.split("_")[1] as UniqueIdentifier);
+        setActiveDealId(activeDealId);
       }
       return;
     }
     if (overData?.type === "Row") {
-      setActiveColumnId(overId.split("/")[1] as UniqueIdentifier);
+      setActiveColumnId(columnName);
       if (
-        DealName.Opportunities.toString() === columnName ||
-        DealName.Proposed.toString() === columnName
+        columnName === DealName.Opportunities.toString() ||
+        columnName === DealName.Proposed.toString()
       ) {
         setActiveDealId(overId);
       } else {
-        setActiveDealId(activeId.split("_")[1] as UniqueIdentifier);
+        setActiveDealId(activeId.split("_")[1]);
       }
       return;
     }
@@ -234,7 +237,6 @@ export const DropContextProvider: React.FC<DndContextProviderProps> = ({
       extractEventData(event.active, event.over);
 
     if (activeId === overId || !activeEmployee || activeColumnId === "Deals") {
-      setIsNotAllowedToMoveOrDrop(true);
       return;
     }
     const isOverAnEmployee = overData?.type === "Employee";
@@ -302,10 +304,17 @@ export const DropContextProvider: React.FC<DndContextProviderProps> = ({
         }
         appendEmployee(employee, activeRowId, overId);
       }
+    } else if (
+      activeRowId === "0" &&
+      activeColumnId &&
+      [DealName.Interview, DealName.Retained, DealName.NonRetained].includes(
+        activeColumnId.toString() as DealName,
+      )
+    ) {
+      // Indicate that dragging from header to other columns is not allowed
+      setIsNotAllowedToMoveOrDrop(true);
     }
 
-    // Otherwise, move is not allowed
-    setIsNotAllowedToMoveOrDrop(true);
     setActiveEmployee(undefined);
   }
 
@@ -467,7 +476,6 @@ export const DropContextProvider: React.FC<DndContextProviderProps> = ({
     )
       return true;
 
-    setIsNotAllowedToMoveOrDrop(true);
     return false;
   }
 

--- a/src/hooks/useSyncScroll.tsx
+++ b/src/hooks/useSyncScroll.tsx
@@ -19,6 +19,11 @@ export function useSyncScroll(columns: NodeListOf<HTMLDivElement> | null) {
     };
 
     const handleScroll = (e: Event) => {
+      // this dissables the detailview when scrolling. This causes a bit of lag (because of rerendering), for maybe 0.5 seconds
+      if (currentEmployeeDetailsId !== "") {
+        setCurrentEmployeeDetailsId("");
+      }
+
       const scrolledEle = e.target as HTMLElement;
       const columnsArray = Array.from(columns);
 
@@ -26,17 +31,6 @@ export function useSyncScroll(columns: NodeListOf<HTMLDivElement> | null) {
         .filter((item) => item !== scrolledEle)
         .forEach((ele) => {
           syncScroll(scrolledEle, ele);
-        });
-    };
-
-    const handleTouchMove = (e: TouchEvent) => {
-      const touchedEle = e.target as HTMLElement;
-      const columnsArray = Array.from(columns);
-
-      columnsArray
-        .filter((item) => item !== touchedEle)
-        .forEach((ele) => {
-          syncScroll(touchedEle, ele);
         });
     };
 

--- a/src/server/api/routers/teamleader/teamleaderService.ts
+++ b/src/server/api/routers/teamleader/teamleaderService.ts
@@ -119,8 +119,8 @@ export const simplifyDeals = async (
       if (!a.estimated_closing_date) return 1; // a is put last
       if (!b.estimated_closing_date) return -1; // b is put last
       return (
-        new Date(a.estimated_closing_date).getTime() -
-        new Date(b.estimated_closing_date).getTime()
+        new Date(b.estimated_closing_date).getTime() -
+        new Date(a.estimated_closing_date).getTime()
       );
     }) as SimplifiedDealArray;
 


### PR DESCRIPTION
# Sprint 7.2

## Deals
### Deal count
A total count was added to see the number of deals that are displayed.

### Deal sorting
The default sorting of the deals is now from newest to oldest.

### General styling changes
Such as the width of a deal and the width of the deals column.

## Bugfixes
### Wrapping
The wrapping of employees in a row is now not altered when a filter is enabled.

### Indication for actions that are not permitted
A bug where toasts were shown even when the action performed was correct was fixed.

### Highlighting the correct row when dragging over an employee
A bug where an onDragOver action was performed over and employeeCard did not highlight the row that it is in (for the Opportunities & Proposed columns). Now a user can see that he/she is dragging over the row even when dragging over an employee in that row.

### Refresh button now refetches instead of reloading the page